### PR TITLE
Rephrase the docs to make it clear that ALTERs of a column introduce a new version

### DIFF
--- a/docs/stable/specification/tables/ducklake_column.md
+++ b/docs/stable/specification/tables/ducklake_column.md
@@ -19,14 +19,16 @@ This table describes the columns that are part of a table, including their types
 | `nulls_allowed`   | `BOOLEAN`   |             |
 | `parent_column`   | `BIGINT`    |             |
 
-- `column_id` is the numeric identifier of the column.
-- `begin_snapshot` refers to a `snapshot_id` from the [`ducklake_snapshot` table]({% link docs/stable/specification/tables/ducklake_snapshot.md %}). The column exists *starting with* this snapshot id.
-- `end_snapshot` refers to a `snapshot_id` from the [`ducklake_snapshot` table]({% link docs/stable/specification/tables/ducklake_snapshot.md %}). The column exists *until* this snapshot id. If `end_snapshot` is `NULL`, the view is currently valid.
+- `column_id` is the numeric identifier of the column, which should persist throughout all versions of the column, until it's dropped.
+- `begin_snapshot` refers to a `snapshot_id` from the [`ducklake_snapshot` table]({% link docs/stable/specification/tables/ducklake_snapshot.md %}). This version of the column exists *starting with* this snapshot id.
+- `end_snapshot` refers to a `snapshot_id` from the [`ducklake_snapshot` table]({% link docs/stable/specification/tables/ducklake_snapshot.md %}). This version of the column exists *until* this snapshot id. If `end_snapshot` is `NULL`, this version of the column is currently valid.
 - `table_id` refers to a `table_id` from the [`ducklake_table` table]({% link docs/stable/specification/tables/ducklake_table.md %}).
 - `column_order` is a number that defines the position of the column in the list of columns. it needs to be unique within a snapshot but does not have to be strictly monotonic (holes are ok).
-- `column_name` is the name of the column, e.g. `my_column`.
-- `column_type` is the type of the column as defined in the list of [data types]({% link docs/stable/specification/data_types.md %}).
+- `column_name` is the name of this version of the column, e.g. `my_column`.
+- `column_type` is the type of this version of the column as defined in the list of [data types]({% link docs/stable/specification/data_types.md %}).
 - `initial_default` is the *initial* default value as the column is being created e.g. in `ALTER TABLE`, encoded as a string. Can be `NULL`.
 - `default_value` is the *operational* default value as data is being inserted and updated, e.g. in `INSERT`, encoded as a string. Can be `NULL`.
-- `nulls_allowed` defines whether `NULL` values are allowed in the column. Note that default values have to be set if this is set to `false`.
-- `parent_column` is the `column_id` of the parent column. This is `NULL` for top-level and non-nested columns. For example, for  `STRUCT` types, this would refer to the "parent" struct column.
+- `nulls_allowed` defines whether `NULL` values are allowed in this version of the column. Note that default values have to be set if this is set to `false`.
+- `parent_column` is the `column_id` of the parent column. This is `NULL` for top-level and non-nested columns. For example, for `STRUCT` types, this would refer to the "parent" struct column.
+
+> Every `ALTER` of the column creates a new version of the column, which will use the same `column_id`.


### PR DESCRIPTION
This PR fixes #34 

1. Rephrased from `the column` to `this version of the column`
2. Fixed mention of `view` to correctly use `column`
3. Added an extra NOTE at the bottom to make it clear that ALTERs of the column introduce a new entry