### PR TITLE
Document the valid `transform` types

### DIFF
--- a/docs/stable/specification/tables/ducklake_partition_column.md
+++ b/docs/stable/specification/tables/ducklake_partition_column.md
@@ -24,7 +24,7 @@ The table of supported transforms is as follows.
 | Transform             |                                    Source Type(s)                                 |                           Description                        | Result&nbsp;Type |
 | --------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------ | ----------- |
 | `identity`            | Any                                                                               | Source value, unmodified                                     | Source type |
-| `year`                | `date`, `timestamp`, `timestamptz`, `timestamp_s`, `timestamp_ms`, `timestamp_ns` | Extract a date or timestamp year, as years from 1970         | `int32`     |
-| `month`               | `date`, `timestamp`, `timestamptz`, `timestamp_s`, `timestamp_ms`, `timestamp_ns` | Extract a date or timestamp month, as months from 1970-01-01 | `int32`     |
-| `day`                 | `date`, `timestamp`, `timestamptz`, `timestamp_s`, `timestamp_ms`, `timestamp_ns` | Extract a date or timestamp day, as days from 1970-01-01     | `int32`     |
-| `hour`                | `timestamp`, `timestamptz`, `timestamp_s`, `timestamp_ms`, `timestamp_ns`         | Extract a timestamp hour, as hours from 1970-01-01 00:00:00  | `int32`     |
+| `year`                | `date`, `timestamp`, `timestamptz`, `timestamp_s`, `timestamp_ms`, `timestamp_ns` | Extract a date or timestamp year, as years from 1970         | `int64`     |
+| `month`               | `date`, `timestamp`, `timestamptz`, `timestamp_s`, `timestamp_ms`, `timestamp_ns` | Extract a date or timestamp month, as months from 1970-01-01 | `int64`     |
+| `day`                 | `date`, `timestamp`, `timestamptz`, `timestamp_s`, `timestamp_ms`, `timestamp_ns` | Extract a date or timestamp day, as days from 1970-01-01     | `int64`     |
+| `hour`                | `timestamp`, `timestamptz`, `timestamp_s`, `timestamp_ms`, `timestamp_ns`         | Extract a timestamp hour, as hours from 1970-01-01 00:00:00  | `int64`     |


### PR DESCRIPTION
This PR fixes #36 

As mentioned in the commit, this shamelessly copies the information from https://iceberg.apache.org/spec/#partition-transforms

Result types are based on this:
```c++
    {"day", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY, "[DATE]>BIGINT"},
    {"day", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY, "[TIMESTAMP]>BIGINT"},
    {"day", "icu", CatalogType::SCALAR_FUNCTION_ENTRY, "[TIMESTAMPTZ]>BIGINT"},
    {"year", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY, "[DATE]>BIGINT"},
    {"year", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY, "[TIMESTAMP]>BIGINT"},
    {"year", "icu", CatalogType::SCALAR_FUNCTION_ENTRY, "[TIMESTAMPTZ]>BIGINT"},
```

It might not be super relevant to mention the result type, because it gets serialized as a string anyways, and I believe comparisons are also done in this serialized format.

Though it is somewhat useful for implementations to know what type of value is expected, if the description wasn't clear enough ?