### PR TITLE
specify compression algorithms for ducklake_metadata table and add `lz4_raw` as a supported codec

### DIFF
--- a/docs/stable/duckdb/usage/configuration.md
+++ b/docs/stable/duckdb/usage/configuration.md
@@ -22,15 +22,15 @@ FROM my_ducklake.options();
 
 ```
 
-|             Name             |                                       Description                                       | Default |
-|------------------------------|-----------------------------------------------------------------------------------------|---------|
-| data_inlining_row_limit      | Maximum amount of rows to inline in a single insert                                     | 0       |
-| parquet_compression          | Compression algorithm for Parquet files (uncompressed, snappy, gzip, zstd, brotli, lz4) | snappy  |
-| parquet_version              | Parquet format version (1 or 2)                                                         | 1       |
-| parquet_compression_level    | Compression level for Parquet files                                                     | 3       |
-| parquet_row_group_size       | Number of rows per row group in Parquet files                                           | 122 880 |
-| parquet_row_group_size_bytes | Number of bytes per row group in Parquet files                                          |         |
-| target_file_size             | The target data file size for insertion and compaction operations                       | 512MB   |
+|             Name             |                                       Description                                                | Default |
+|------------------------------|--------------------------------------------------------------------------------------------------|---------|
+| data_inlining_row_limit      | Maximum amount of rows to inline in a single insert                                              | 0       |
+| parquet_compression          | Compression algorithm for Parquet files (uncompressed, snappy, gzip, zstd, brotli, lz4, lz4_raw) | snappy  |
+| parquet_version              | Parquet format version (1 or 2)                                                                  | 1       |
+| parquet_compression_level    | Compression level for Parquet files                                                              | 3       |
+| parquet_row_group_size       | Number of rows per row group in Parquet files                                                    | 122 880 |
+| parquet_row_group_size_bytes | Number of bytes per row group in Parquet files                                                   |         |
+| target_file_size             | The target data file size for insertion and compaction operations                                | 512MB   |
 
 ### Scoping
 Options can be set either globally, per-schema or per-table.

--- a/docs/stable/specification/tables/ducklake_metadata.md
+++ b/docs/stable/specification/tables/ducklake_metadata.md
@@ -35,6 +35,6 @@ Currently, the following values for `key` are specified:
 | `target_file_size`      | The size in bytes to limit a parquet file at for insert and compaction operations   |   | Global, Schema or Table      |
 | `parquet_row_group_size_bytes` | The size in bytes to limit a parquet file rowgroup at for insert and compaction operations | | Global, Schema or Table |
 | `parquet_row_group_size` | The size in number of rows to limit a parquet file rowgroup at for insert and compaction operations | | Global, Schema or Table |
-| `parquet_compression` | The compression used to write parquet files e.g., `zstd` | | Global, Schema or Table |
+| `parquet_compression` | The compression used to write parquet files e.g., `zstd` | `uncompressed`, `snappy`, `gzip`, `zstd`, `brotli`, `lz4`, `lz4_raw` | Global, Schema or Table |
 | `parquet_compression_level` | The compression level used for the selected `parquet_compression` | | Global, Schema or Table |
 | `parquet_version` | The version of the Parquet standard used to write parquet files | `1` or `2` | Global, Schema or Table |


### PR DESCRIPTION
based on https://github.com/duckdb/ducklake/blob/ee82564f1dc54f1ba797b06b2e7ac9970f95dd0c/src/functions/ducklake_options.cpp#L20