### PR TITLE
Clarify that `partition_id` is incremented from `next_catalog_id`

### DIFF
--- a/docs/stable/specification/tables/ducklake_partition_info.md
+++ b/docs/stable/specification/tables/ducklake_partition_info.md
@@ -10,7 +10,7 @@ title: ducklake_partition_info
 | `begin_snapshot` | `BIGINT`    |             |
 | `end_snapshot`   | `BIGINT`    |             |
 
-- `partition_id` is a numeric identifier for a partition.
+- `partition_id` is a numeric identifier for a partition. `partition_id` is incremented from `next_catalog_id` in the [`ducklake_snapshot` table]({% link docs/stable/specification/tables/ducklake_snapshot.md %}).
 - `table_id` refers to a `table_id` from the [`ducklake_table` table]({% link docs/stable/specification/tables/ducklake_table.md %}). 
 - `begin_snapshot` refers to a `snapshot_id` from the [`ducklake_snapshot` table]({% link docs/stable/specification/tables/ducklake_snapshot.md %}). The partition is valid *starting with* this snapshot id.
 - `end_snapshot` refers to a `snapshot_id` from the [`ducklake_snapshot` table]({% link docs/stable/specification/tables/ducklake_snapshot.md %}). The partition is valid *until* this snapshot id. If `end_snapshot` is `NULL`, the partition is currently valid.


### PR DESCRIPTION
can be seen here: https://github.com/duckdb/ducklake/blob/f84ab92354579d64a4f0a2a2f40335260972fae4/src/storage/ducklake_transaction.cpp#L551