### PR TITLE
Update upserting.md

### DIFF
--- a/docs/stable/duckdb/usage/upserting.md
+++ b/docs/stable/duckdb/usage/upserting.md
@@ -92,7 +92,7 @@ FROM people;
 | 3  | Sarah | 95000.0  |
 
 
-`MERGE INTO` also supports more complex conditions, for example for a given delete set we can decide to only remove rows that contain a `salary` bigger than a certain amount.
+`MERGE INTO` also supports more complex conditions, for example for a given delete set we can decide to only remove rows that contain a `salary` greater than or equal to a certain amount.
 
 ```sql
 MERGE INTO people


### PR DESCRIPTION
1. Insert was done with John, but rest of the example uses Jhon. John is more common way of spelling, but it's possible that the author intended to show how update changes the entire column.
2. Anna's salary was never updated, so it should stay at 100_000, which then breaks the 2nd to last example, unless we change the merge condition to >=.
3. One dangling comma

<img width="620" height="717" alt="Screenshot 2025-10-11 at 6 28 20 PM" src="https://github.com/user-attachments/assets/fc7dae7c-e24f-4ad3-8092-0163d8b26cb2" />
<img width="582" height="878" alt="Screenshot 2025-10-11 at 6 28 54 PM" src="https://github.com/user-attachments/assets/80c6c7a3-c370-46c7-ac29-a0ae555ba13f" />
<img width="541" height="304" alt="Screenshot 2025-10-11 at 6 30 16 PM" src="https://github.com/user-attachments/assets/9fb63ccd-cd42-4c20-86a4-1e819de598cd" />


@szarnyasg