### PR TITLE
bug: generate single-file docs in generate_md_files.sh

### DIFF
--- a/scripts/generate_md_files.sh
+++ b/scripts/generate_md_files.sh
@@ -5,6 +5,14 @@ set -xeuo pipefail
 # navigate to the repository root
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
 
+# Generate single-file documentation
+cd single-file-document
+python3 concatenate_to_single_file.py
+./clean_markdown_file.sh
+sed -i '1s/^.*$/# DuckLake Documentation/' ducklake-docs-cleaned.md
+cp ducklake-docs-cleaned.md ../ducklake-docs.md
+cd ..
+
 shopt -s extglob
 rm -rf docs/!(stable)
 find . -name '*.md' | xargs -I {} sed -E -i 's|\{% link ([^\}]*) %\}|https://ducklake.select/\1|g' {}


### PR DESCRIPTION
Fixes #215 .
As far as I can tell, before GitHub Actions workflow was updated, the jekyll.yml workflow had a dedicated build_pdf job that:
  1. Generated the single-file markdown documentation
  2. Built the PDF
  3. Packaged both into the deployment artifacts

When the workflow was removed, I believe the markdown generation step was lost, causing the 404 error.

The fix: Updated scripts/generate_md_files.sh to generate the ducklake-docs.md file before copying markdown files to _site/.

  The script now:
  1. Runs the Python concatenation script to generate the combined markdown
  2. Cleans the markdown file
  3. Copies it to the root as ducklake-docs.md
  4. Includes it when copying *.md files to _site/

  This script is likely being called during the deployment build process (based on the old workflow that referenced it). Once the deployment runs with this change, the
  /ducklake-docs.md URL should work.

  Summary of changes:
  - Modified scripts/generate_md_files.sh (scripts/generate_md_files.sh:8-14) to generate the single-file documentation before Jekyll builds the site

  The 404 should be resolved after the next deployment.