### PR TITLE
fix: USAGE is not a table level privilege

### DIFF
--- a/docs/stable/duckdb/guides/access_control.md
+++ b/docs/stable/duckdb/guides/access_control.md
@@ -64,7 +64,7 @@ GRANT CREATE, SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO d
 -- Writer/reader
 CREATE USER ducklake_writer WITH PASSWORD 'simple';
 GRANT USAGE ON SCHEMA public TO ducklake_writer;
-GRANT USAGE, SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ducklake_writer;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ducklake_writer;
 
 -- Reader only
 CREATE USER ducklake_reader WITH PASSWORD 'simple';


### PR DESCRIPTION
Current GRANT statement in the docs for role 'writer/reader' is not correct:

```
GRANT USAGE, SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ducklake_writer;
ERROR:  invalid privilege type USAGE for table
```

According to the docs, `USAGE` is indeed not a valid access privilege on table level (it should be provided on schema level):
https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGE-ABBREVS-TABLE