### PR TITLE
docs: add grant schema usage to ducklake_reader as is the cases for d…

### DIFF
--- a/docs/stable/duckdb/guides/access_control.md
+++ b/docs/stable/duckdb/guides/access_control.md
@@ -68,6 +68,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ducklake_
 
 -- Reader only
 CREATE USER ducklake_reader WITH PASSWORD 'simple';
+GRANT USAGE ON SCHEMA public TO ducklake_reader;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO ducklake_reader;
 ```
 


### PR DESCRIPTION
…ucklake_writer and ducklake_superuser

I am deploying a ducklake instance using postgresql and am following [the example docs]().

I noticed that the docs covers `GRANT USAGE ON SCHEMA public TO ducklake_superuser/writer` but misses this for `ducklake_reader`

Unless I'm missing something, this should still be granted for `ducklake_reader` since `USAGE` on a schema is required for ["access to objects contained in the schema"](https://www.postgresql.org/docs/current/ddl-priv.html#DDL-PRIV-USAGE) including tables, so it's a bit of a pre-requisite.

I imagine this was just missed out/accidentally deleted.
This is a one-line fix to correct the miss.