### PR TITLE
Rename column 'snapshot_changes' to 'changes_made'

### DIFF
--- a/docs/stable/specification/queries.md
+++ b/docs/stable/specification/queries.md
@@ -177,7 +177,7 @@ VALUES (
 
 INSERT INTO ducklake_snapshot_changes (
     snapshot_id,
-    snapshot_changes,
+    changes_made,
     author,
     commit_message,
     commit_extra_info


### PR DESCRIPTION
Align the column name in the write example with [the table spec](https://ducklake.select/docs/stable/specification/tables/ducklake_snapshot_changes). The example seems to be using an outdated column name (`snapshot_changes`).