### PR TITLE
Simplify "Get Current Snapshot" query

### DIFF
--- a/docs/stable/specification/queries.md
+++ b/docs/stable/specification/queries.md
@@ -19,10 +19,8 @@ DuckLake specifies _tables_ and _update transactions_ to modify them. DuckLake i
 Before anything else we need to find a snapshot id to be queried. There can be many snapshots in the [`ducklake_snapshot` table]({% link docs/stable/specification/tables/ducklake_snapshot.md %}). A snapshot id is a continuously increasing number that identifies a snapshot. In most cases, you would query the most recent one like so:
 
 ```sql
-SELECT snapshot_id
-FROM ducklake_snapshot
-WHERE snapshot_id =
-    (SELECT max(snapshot_id) FROM ducklake_snapshot);
+SELECT max(snapshot_id)
+FROM ducklake_snapshot;
 ```
 
 ### List Schemas


### PR DESCRIPTION
The [Get Current Snapshot](https://ducklake.select/docs/stable/specification/queries#get-current-snapshot) query in the Queries spec uses a redundant nested subquery that makes it a bit confusing to read:

```sql
-- Current:
SELECT snapshot_id FROM ducklake_snapshot WHERE snapshot_id = (SELECT max(snapshot_id) FROM ducklake_snapshot);

-- Proposed:
SELECT max(snapshot_id) FROM ducklake_snapshot;
```

P.S. Thanks for hosting DuckCon, it was a blast! 🦆❤️ 